### PR TITLE
Fix oven temperature conversion

### DIFF
--- a/episodes/recipe_instructions.Rmd
+++ b/episodes/recipe_instructions.Rmd
@@ -34,7 +34,8 @@ exercises: 2
 
 - Mix the brown sugar and cinnamon in a small bowl.
 - In a separate bowl, mix the glaze ingredients.
-- Preheat oven to 375°F (290°C) and batter a 12" cast iron skillet or deep baking container (glass or enamel will work just fine).
+- Preheat oven to 375°F (190°C) and batter a 12" cast iron skillet or deep baking container (glass or enamel will work just 
+fine).
 
 **Add leavening agents to dough:**
 


### PR DESCRIPTION
Fixes #2 by correcting the converted oven temperature in Celsius.
